### PR TITLE
Support ios device tokens and add little info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # OneSignal
 
-A description of this package.
+Using OneSignal on Vapor.
+
+For sending to an array of device tokens:
+
+```swift
+let deviceTokens = ["foo...", "bar..."]
+let message = OneSignalMessage("Hello Vapor!")
+let notif = OneSignalNotification(message: message, iosDeviceTokens: [deviceTokens])
+let app = OneSignalApp(apiKey: Environment.get("ONESIGNAL_API_KEY") ?? "", appId: Environment.get("ONESIGNAL_APP_ID") ?? "")
+let result = try OneSignal.makeService(for: request).send(notification: notif, toApp: app)
+```

--- a/Sources/OneSignal/OneSignalNotification.swift
+++ b/Sources/OneSignal/OneSignalNotification.swift
@@ -11,6 +11,7 @@ import Vapor
 public struct OneSignalNotification: Codable {
     enum CodingKeys: String, CodingKey {
         case users
+        case iosDeviceTokens
         
         case title
         case subtitle
@@ -24,7 +25,8 @@ public struct OneSignalNotification: Codable {
         case isContentMutable = "mutable_content"
     }
     
-    public var users: [String]
+    public var users: [String]? = []
+    public var iosDeviceTokens: [String]? = []
     
     public var title: OneSignalMessage?
     public var subtitle: OneSignalMessage?
@@ -57,11 +59,17 @@ public struct OneSignalNotification: Codable {
         self.users = users
     }
     
-    public init(title: String?, subtitle: String?, body: String, users: [String], sound: String? = nil, category: String? = nil) {
+    public init(message: OneSignalMessage, iosDeviceTokens: [String]) {
+        self.message = message
+        self.iosDeviceTokens = iosDeviceTokens
+    }
+    
+    public init(title: String?, subtitle: String?, body: String, users: [String]?, iosDeviceTokens: [String]?, sound: String? = nil, category: String? = nil) {
         if let title = title { self.title = OneSignalMessage(title) }
         if let subtitle = subtitle { self.subtitle = OneSignalMessage(subtitle) }
         self.message = OneSignalMessage(body)
         self.users = users
+        self.iosDeviceTokens = iosDeviceTokens
         self.sound = sound
         self.category = category
     }
@@ -69,7 +77,8 @@ public struct OneSignalNotification: Codable {
 
 extension OneSignalNotification {
     public mutating func addUser(_ id: String) {
-        self.users.append(id)
+        guard var users = users else { return }
+        users.append(id)
     }
     
     public mutating func addMessage(_ message: String, language: String = "en") {
@@ -114,7 +123,8 @@ extension OneSignalNotification {
         
         let payload = OneSignalPayload(
             appId: app.appId,
-            playerIds: self.users,
+            playerIds: self.users ?? [],
+            iosDeviceTokens: self.iosDeviceTokens ?? [],
             contents: self.message.messages,
             headings: self.title?.messages,
             subtitle: self.subtitle?.messages,

--- a/Sources/OneSignal/OneSignalPayload.swift
+++ b/Sources/OneSignal/OneSignalPayload.swift
@@ -12,7 +12,8 @@ public struct OneSignalPayload: Content {
     enum CodingKeys: String, CodingKey {
         case appId = "app_id"
         case playerIds = "include_player_ids"
-        
+        case iosDeviceTokens = "include_ios_tokens"
+
         case contents = "contents"
         case headings = "headings"
         case subtitle = "subtitle"
@@ -24,7 +25,8 @@ public struct OneSignalPayload: Content {
     public var appId: String
 
     public var playerIds: [String]
-    
+    public var iosDeviceTokens: [String]
+
     public var contents: [String: String]
     
     public var headings: [String: String]?


### PR DESCRIPTION
There was no way to send PNs using just the pure device tokens and no user ids or anything else.